### PR TITLE
imports em ordem alfabetica e os desnecessarios (metafield e java.lang) removido

### DIFF
--- a/src/main/java/br/ufsc/bridge/metafy/FakeTypeElement.java
+++ b/src/main/java/br/ufsc/bridge/metafy/FakeTypeElement.java
@@ -1,6 +1,8 @@
 package br.ufsc.bridge.metafy;
 
 import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.TypeElement;
@@ -54,20 +56,26 @@ public class FakeTypeElement {
 		this.qualifiedName = typeElement.getQualifiedName().toString();
 	}
 
-	public String getImport() {
+	public List<String> getImport() {
+		List<String> imports = new ArrayList<>();
 		if (this.internalMetafy) {
-			return String.format("import %s;", this.qualifiedName.replace(this.simpleName, MetafyConstants.PREFIX + this.simpleName));
+			imports.add(String.format("import %s;", this.qualifiedName.replace(this.simpleName, MetafyConstants.PREFIX + this.simpleName)));
+
 		} else if (!this.primitive) {
-			String format = String.format("import %s;", this.qualifiedName);
-			if (this.isList(this.qualifiedName)) {
-				format += "\n" + String.format("import %s;", MetaList.class.getName());
-			} else if (this.isSet(this.qualifiedName)) {
-				format += "\n" + String.format("import %s;", MetaSet.class.getName());
+
+			if (!this.qualifiedName.startsWith("java.lang")) {
+				imports.add(String.format("import %s;", this.qualifiedName));
 			}
-			return format;
-		} else {
-			return null;
+
+			if (this.isList(this.qualifiedName)) {
+				imports.add(String.format("import %s;", MetaList.class.getName()));
+			} else if (this.isSet(this.qualifiedName)) {
+				imports.add(String.format("import %s;", MetaSet.class.getName()));
+			} else {
+				imports.add(String.format("import %s;", MetaField.class.getName()));
+			}
 		}
+		return imports;
 	}
 
 	public void writeAttribute(PrintWriter pw) {

--- a/src/main/java/br/ufsc/bridge/metafy/MetaBean.java
+++ b/src/main/java/br/ufsc/bridge/metafy/MetaBean.java
@@ -20,15 +20,15 @@ public class MetaBean<T> extends MetaField<T> {
 	}
 
 	protected <TYPE> MetaField<TYPE> createField(Class<TYPE> fieldType, String fieldName) {
-		return new MetaField<TYPE>(this, fieldType, fieldName);
+		return new MetaField<>(this, fieldType, fieldName);
 	}
 
 	protected <TYPE> MetaList<TYPE> createList(String fieldName) {
-		return new MetaList<TYPE>(this, fieldName);
+		return new MetaList<>(this, fieldName);
 	}
 
 	protected <TYPE> MetaSet<TYPE> createSet(String fieldName) {
-		return new MetaSet<TYPE>(this, fieldName);
+		return new MetaSet<>(this, fieldName);
 	}
 
 }

--- a/src/main/java/br/ufsc/bridge/metafy/processor/MetafyClass.java
+++ b/src/main/java/br/ufsc/bridge/metafy/processor/MetafyClass.java
@@ -20,8 +20,8 @@ public class MetafyClass {
 		this.simpleReferenceName = completeName.substring(completeName.lastIndexOf(".") + 1, completeName.length());
 		this.simpleName = MetafyConstants.PREFIX + this.simpleReferenceName;
 		this.completeName = this.packageName + "." + this.simpleName;
-		this.imports = new ArrayList<String>();
-		this.fakeTypes = new ArrayList<FakeTypeElement>();
+		this.imports = new ArrayList<>();
+		this.fakeTypes = new ArrayList<>();
 	}
 
 	public void importType(String element) {

--- a/src/main/java/br/ufsc/bridge/metafy/processor/MetafyClassSerializer.java
+++ b/src/main/java/br/ufsc/bridge/metafy/processor/MetafyClassSerializer.java
@@ -3,8 +3,8 @@ package br.ufsc.bridge.metafy.processor;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.tools.JavaFileObject;
@@ -25,19 +25,17 @@ public class MetafyClassSerializer {
 		pw.println(String.format("package %s;", data.getPackageName()));
 		pw.println();
 
+		Set<String> imports = new TreeSet<>();
 		for (String importString : data.getImports()) {
-			pw.println(String.format("import %s;", importString));
+			imports.add(String.format("import %s;", importString));
 		}
-
-		pw.println();
-
-		Set<String> imports = new HashSet<>();
 		for (FakeTypeElement e : data.getFakeTypes()) {
-			String value = e.getImport();
-			if (value != null && !imports.contains(value)) {
-				pw.println(value);
+			for (String value : e.getImport()) {
 				imports.add(value);
 			}
+		}
+		for (String value : imports) {
+			pw.println(value);
 		}
 
 		pw.println();

--- a/src/main/java/br/ufsc/bridge/metafy/processor/MetafyProcessor.java
+++ b/src/main/java/br/ufsc/bridge/metafy/processor/MetafyProcessor.java
@@ -15,7 +15,6 @@ import javax.tools.Diagnostic.Kind;
 
 import br.ufsc.bridge.metafy.FakeTypeElement;
 import br.ufsc.bridge.metafy.MetaBean;
-import br.ufsc.bridge.metafy.MetaField;
 import br.ufsc.bridge.metafy.Metafy;
 
 @SupportedAnnotationTypes("br.ufsc.bridge.metafy.Metafy")
@@ -44,7 +43,6 @@ public class MetafyProcessor extends AbstractProcessor {
 						data = new MetafyClass(typeElement.getQualifiedName().toString());
 					}
 
-					data.importType(MetaField.class.getName());
 					data.importType(MetaBean.class.getName());
 					data.importType(typeElement.getQualifiedName().toString());
 					for (VariableElement e : ElementFilter.fieldsIn(typeElement.getEnclosedElements())) {


### PR DESCRIPTION
O import do MetaField é desnecessário em alguns casos onde só se tem atributos do tipo List ou Set e nenhum tipo java.lang é necessário o import.